### PR TITLE
fix: use constructed `url` for tunnel

### DIFF
--- a/src/tunnel.ts
+++ b/src/tunnel.ts
@@ -48,7 +48,7 @@ export async function startTunnel(
   }
 
   const args = [
-    ["--url", opts.url],
+    ["--url", url],
     opts.verifyTLS ? undefined : ["--no-tls-verify", ""],
   ].filter(Boolean) as [string, string][];
 


### PR DESCRIPTION
While using startTunnel, I noticed it hangs on execution:

```ts
const tunnel = await startTunnel({ port: 8787 });
console.log(await tunnel?.getURL()); // This hangs here
```

Setting the environment variable `DEBUG=true` and checking the logs, it was apparent that the --url wasn't being passed correctly:

```
◐ Starting cloudflared tunnel to http://localhost:8787                                                                                                                                                                                                                               You did not specify any valid additional argument to the cloudflared tunnel command.

If you are trying to run a Quick Tunnel then you need to explicitly pass the --url flag.
Eg. cloudflared tunnel --url localhost:8080/.

Please note that Quick Tunnels are meant to be ephemeral and should only be used for testing purposes.
For production usage, we recommend creating Named Tunnels. (https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/install-and-setup/tunnel-guide/)
```

I believe the reference to options.url here should actually be url:

```ts
  const args = [
    ["--url", options.url],
    opts.verifyTLS ? void 0 : ["--no-tls-verify", ""]
  ].filter(Boolean);
```
Upon patching this locally, I confirmed that the change resolves the issue and everything works as expected.