### PR TITLE
fix: args port, hostname & protocol was ignored when url is not present

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -30,8 +30,10 @@ export const tunnel = defineCommand({
     },
   },
   async run({ args }) {
-    const tunnel = await startTunnel({
-      url: args.url,
+    const tunnel = await startTunnel(args.url ? { url: args.url } : {
+      port: args.port,
+      hostname: args.hostname,
+      protocol: args.protocol as 'http' | 'https' | undefined
     });
 
     if (!tunnel) {


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->
### Before The Arguments was getting ignored
![image](https://github.com/user-attachments/assets/1f4eff4c-2f0c-453c-820e-bc1bae8ba37c)
---

### After Now the arguments was getting directed
![image](https://github.com/user-attachments/assets/da41dcf3-706f-4095-aca9-99769bd0bbe2)